### PR TITLE
Add a MIPS Docker image

### DIFF
--- a/.azure-pipelines/variables.yml
+++ b/.azure-pipelines/variables.yml
@@ -9,4 +9,5 @@ variables:
   windows_image: 'windows-2019'
   cross_tag: 'v0.1.16'
   target_arm_unknown_linux_musleabihf: 'arm-unknown-linux-musleabihf'
+  target_mips_unknown_linux_gnu: 'mips-unknown-linux-gnu'
   target_x86_64_unknown_linux_musl: 'x86_64-unknown-linux-musl'

--- a/cross-images/01_debian_populate.sh
+++ b/cross-images/01_debian_populate.sh
@@ -1,0 +1,30 @@
+#! /bin/bash
+# Copyright 2019 The Tectonic Project
+# Licensed under the MIT License.
+
+set -xeuo pipefail
+
+apt-get install -y \
+        binfmt-support \
+        crossbuild-essential-${debian_arch} \
+        pkg-config \
+        qemu \
+        qemu-user-static \
+        sudo
+
+# Must do this in two stages because mips openssl messes up amd64 openssl.
+
+apt-get install -y \
+        libgraphite2-dev:${debian_arch} \
+        libharfbuzz-dev:${debian_arch} \
+        libfontconfig1-dev:${debian_arch} \
+        libfreetype6-dev:${debian_arch} \
+        libicu-dev:${debian_arch} \
+        libssl-dev:${debian_arch} \
+        openssl:${debian_arch} \
+        zlib1g-dev:${debian_arch}
+
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+rm -f "$0"  # self-destruct

--- a/cross-images/02_debian_setup_env.sh
+++ b/cross-images/02_debian_setup_env.sh
@@ -1,0 +1,40 @@
+#! /bin/bash
+# Copyright 2019 The Tectonic Project
+# Licensed under the MIT License.
+
+set -xeuo pipefail
+
+urp="$(echo $rust_platform |tr - _)"
+crp="$(echo $urp |tr '[a-z]' '[A-Z]')"
+
+RUSTFLAGS="-L /usr/lib/${debian_platform}"
+
+cat <<EOF >/environ
+export AR_${urp}="${debian_platform}-ar"
+export CC_${urp}="${debian_platform}-gcc"
+export CXX_${urp}="${debian_platform}-g++"
+export CARGO_TARGET_${crp}_LINKER="${debian_platform}-g++"
+
+export OPENSSL_LIB_DIR=/usr/lib/${debian_platform}
+export OPENSSL_INCLUDE_DIR=/usr/include
+export PKG_CONFIG_LIBDIR=/usr/lib/${debian_platform}/pkgconfig
+
+export RUSTFLAGS="$RUSTFLAGS"
+export PKG_CONFIG_ALLOW_CROSS=1
+export RUST_TEST_THREADS=1
+export RUST_BACKTRACE=1
+EOF
+
+# The OpenSSL includes are split between /usr/include (platform-independent)
+# and /usr/include/${debian_platform} (platform-dependent). I don't believe
+# that openssl-sys is smart enough to deal with that well. Since we're in a
+# container, just hack it:
+cp /usr/include/${debian_platform}/openssl/*.h /usr/include/openssl/
+
+if [ $qemu_arch != native ] ; then
+    cat <<EOF >>/environ
+export CARGO_TARGET_${crp}_RUNNER=qemu-${qemu_arch}-static
+EOF
+fi
+
+rm -f "$0"  # self-destruct

--- a/cross-images/Dockerfile.debian-cross
+++ b/cross-images/Dockerfile.debian-cross
@@ -1,0 +1,23 @@
+# Copyright 2019 The Tectonic Project
+# Licensed under the MIT License.
+
+FROM debian:buster
+
+ARG UID=1000
+ARG rust_platform
+ARG debian_platform
+ARG debian_arch
+ARG qemu_arch
+
+ENV TERM=dumb
+RUN dpkg --add-architecture ${debian_arch} && apt-get update
+ADD 01_debian_populate.sh /
+RUN /bin/bash /01_debian_populate.sh
+
+ADD 02_debian_setup_env.sh /
+RUN /bin/bash /02_debian_setup_env.sh
+
+WORKDIR /project
+ADD debian-entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["cargo", "test", "--release", "--all"]

--- a/cross-images/build.mips-unknown-linux-gnu.sh
+++ b/cross-images/build.mips-unknown-linux-gnu.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+# Copyright 2019 The Tectonic Project
+# Licensed under the MIT License.
+
+[ -n "$IMGUID" ] || IMGUID="$(id -u)"
+rust_platform=mips-unknown-linux-gnu
+debian_platform=mips-linux-gnu
+debian_arch=mips
+qemu_arch=mips
+
+cd "$(dirname $0)" && \
+    exec docker build \
+         -t tectonictypesetting/crossbuild:$rust_platform \
+         -f Dockerfile.debian-cross \
+         --build-arg UID=$IMGUID \
+         --build-arg rust_platform=$rust_platform \
+         --build-arg debian_platform=$debian_platform \
+         --build-arg debian_arch=$debian_arch \
+         --build-arg qemu_arch=$qemu_arch \
+         .

--- a/cross-images/debian-entrypoint.sh
+++ b/cross-images/debian-entrypoint.sh
@@ -1,0 +1,34 @@
+#! /usr/bin/env bash
+# Copyright 2019 the Tectonic Project
+# Licensed under the MIT license.
+
+set -euo pipefail
+
+# This script shouldn't be necessary since we don't need to chroot in the
+# debian-cross builder, but we want to use the same `cross` driver for that
+# and for the alpine-cross one that does, so we have to jump through the same
+# hoops.
+
+# Ensure that there exist a user and group with the desired UID/GID.
+
+groupname="$(getent group $HOST_GID |cut -d: -f1 || true)"
+if [ -z "$groupname" ] ; then
+    groupname="gid${HOST_GID}"
+    addgroup -q --gid $HOST_GID "$groupname"
+fi
+
+username="$(getent passwd $HOST_UID |cut -d: -f1 || true)"
+if [ -z "$username" ] ; then
+    username="user${HOST_UID}"
+    adduser -q --gid $HOST_GID --uid $HOST_UID --disabled-password --gecos "UID $HOST_UID" "$username"
+fi
+
+cur_prim_gid="$(getent passwd $HOST_UID |cut -d: -f4)"
+if [ "$cur_prim_gid" -ne "$HOST_GID" ] ; then
+    usermod -g $HOST_GID "$username"
+fi
+
+# We can now run the command with the desired UID/GID.
+
+export HOME="$(getent passwd $HOST_UID |cut -d: -f6)"
+exec sudo -E -u "$username" sh -c '. /environ ; "$@"' -- "${@:-sh}"


### PR DESCRIPTION
This one is a big-endian architecture, which will let us start testing that configuration without having to rely on the awful Circle CI builder.