### PR TITLE
Add a cross image for i686-unknown-linux-gnu

### DIFF
--- a/.azure-pipelines/variables.yml
+++ b/.azure-pipelines/variables.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 the Tectonic Project
+# Copyright 2019-2021 the Tectonic Project
 # Licensed under the MIT License.
 
 # This files sets global variables that are shared among various pipelines.
@@ -9,5 +9,6 @@ variables:
   windows_image: 'windows-2019'
   cross_tag: 'v0.1.16'
   target_arm_unknown_linux_musleabihf: 'arm-unknown-linux-musleabihf'
+  target_i686_unknown_linux_gnu: 'i686-unknown-linux-gnu'
   target_mips_unknown_linux_gnu: 'mips-unknown-linux-gnu'
   target_x86_64_unknown_linux_musl: 'x86_64-unknown-linux-musl'

--- a/cross-images/01_debian_populate.sh
+++ b/cross-images/01_debian_populate.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2019 The Tectonic Project
+# Copyright 2019-2021 The Tectonic Project
 # Licensed under the MIT License.
 
 set -xeuo pipefail
@@ -11,6 +11,22 @@ apt-get install -y \
         qemu \
         qemu-user-static \
         sudo
+
+# for x86, we have to specify the platform as i386, but the GCC executables are
+# named as `i686-linux-gnu...`, which messes things up later. Work around with
+# some lame symlinks.
+
+if [ ${debian_platform} = i386-linux-gnu ] ; then
+    toolchain_platform=i686-linux-gnu
+    pushd /usr/bin
+
+    for t in ${toolchain_platform}-* ; do
+        alt=$(echo $t |sed -e s/${toolchain_platform}/${debian_platform}/)
+        ln -s $t $alt
+    done
+
+    popd
+fi
 
 # Must do this in two stages because mips openssl messes up amd64 openssl.
 

--- a/cross-images/build.i686-unknown-linux-gnu.sh
+++ b/cross-images/build.i686-unknown-linux-gnu.sh
@@ -1,0 +1,20 @@
+#! /usr/bin/env bash
+# Copyright 2019-2021 The Tectonic Project
+# Licensed under the MIT License.
+
+[ -n "$IMGUID" ] || IMGUID="$(id -u)"
+rust_platform=i686-unknown-linux-gnu
+debian_platform=i386-linux-gnu
+debian_arch=i386
+qemu_arch=native
+
+cd "$(dirname $0)" && \
+    exec docker build \
+         -t tectonictypesetting/crossbuild:$rust_platform \
+         -f Dockerfile.debian-cross \
+         --build-arg UID=$IMGUID \
+         --build-arg rust_platform=$rust_platform \
+         --build-arg debian_platform=$debian_platform \
+         --build-arg debian_arch=$debian_arch \
+         --build-arg qemu_arch=$qemu_arch \
+         .


### PR DESCRIPTION
This gives us an environment to test for 32-bit systems. Cf:

https://github.com/tectonic-typesetting/tectonic/issues/749