### PR TITLE
cross-images: update x86_64-musl for Rust 1.52

### DIFF
--- a/cross-images/04_ubuntu_priv_setup.sh
+++ b/cross-images/04_ubuntu_priv_setup.sh
@@ -9,9 +9,9 @@ UID="$UID"
 
 cd /
 
-export TERM=dumb
+export TERM=dumb DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y pkg-config sudo
+apt-get install -y build-essential pkg-config sudo
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 

--- a/cross-images/Dockerfile.alpine-chroot
+++ b/cross-images/Dockerfile.alpine-chroot
@@ -25,7 +25,7 @@ RUN sh /03_alpine_populate.sh native
 
 # We're done setting up Alpine. Now switch to an Ubuntu image and embed
 # the Alpine system in it.
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 ARG UID=1000
 ARG rust_platform
 ARG alpine_platform

--- a/cross-images/linkwrapper.sh.in
+++ b/cross-images/linkwrapper.sh.in
@@ -1,5 +1,5 @@
 #! /bin/bash
-# Copyright 2019 The Tectonic Project
+# Copyright 2019-2021 The Tectonic Project
 # Licensed under the MIT License.
 
 # This script derived from GitHub user @dl00:
@@ -24,10 +24,8 @@ for arg in "$@"; do
         args+=("-no-pie")
     elif [[ $arg = *"rcrt1.o"* ]]; then
         args+=($(echo "$arg" |sed -e s/rcrt1/crt1/))
-    elif [[ $arg = *"crti.o"* ]]; then
-        args+=("$arg" "$gcclibdir/crtbeginT.o" "-Bstatic")
     elif [[ $arg = *"crtn.o"* ]]; then
-        args+=("-lgcc" "-lgcc_eh" "-lc" "$gcclibdir/crtend.o" "$arg")
+        args+=("-lc" "$arg")
     else
         args+=("$arg")
     fi


### PR DESCRIPTION
It looks like Rust 1.52 is bundling more of its own "crt" object files, and we need to tweak our link wrapper to suit. Still need to add a manual link to libc. Also some various bits of housekeeping.