### PR TITLE
cross-images: recent x86_64 change broke arm/musl

### DIFF
--- a/cross-images/05_ubuntu_unpriv_setup.sh
+++ b/cross-images/05_ubuntu_unpriv_setup.sh
@@ -1,5 +1,5 @@
 #! /bin/sh
-# Copyright 2019 The Tectonic Project
+# Copyright 2019-2021 The Tectonic Project
 # Licensed under the MIT License.
 
 set -x
@@ -12,10 +12,21 @@ toolprefix="$3"
 cd
 mkdir $HOME/bin
 
+if [ "$rust_platform" = x86_64-unknown-linux-musl ] ; then
+    # 2021 May: It seems that Rust 1.52 has started bundling more of its
+    # own "crt" files, and we should no longer link with -lgcc, among
+    # other changes. For our other platform that uses this framework,
+    # arm-unknown-linux-musleabihf, we shouldn't change.
+    force_crt=false
+else
+    force_crt=true
+fi
+
 for tmpl in toolwrapper.sh linkwrapper.sh ; do
     sed -e "s|@rust_platform@|$rust_platform|g" \
         -e "s|@os_platform@|$os_platform|g" \
         -e "s|@toolprefix@|$toolprefix|g" \
+        -e "s|@force_crt@|$force_crt|g" \
         $tmpl.in >bin/$tmpl
     chmod +x bin/$tmpl
 done

--- a/cross-images/linkwrapper.sh.in
+++ b/cross-images/linkwrapper.sh.in
@@ -7,6 +7,7 @@
 
 rust_platform="@rust_platform@"
 os_platform="@os_platform@"
+force_crt="@force_crt@"
 
 gcclibdir="$(echo /alpine/usr/lib/gcc/$os_platform/*/crtbeginT.o)"
 gcclibdir="${gcclibdir%/crtbeginT.o}"
@@ -24,8 +25,16 @@ for arg in "$@"; do
         args+=("-no-pie")
     elif [[ $arg = *"rcrt1.o"* ]]; then
         args+=($(echo "$arg" |sed -e s/rcrt1/crt1/))
+    elif [[ $arg = *"crti.o"* ]]; then
+        if $force_crt ; then
+            args+=("$arg" "$gcclibdir/crtbeginT.o" "-Bstatic")
+        fi
     elif [[ $arg = *"crtn.o"* ]]; then
-        args+=("-lc" "$arg")
+        if $force_crt ; then
+            args+=("-lgcc" "-lgcc_eh" "-lc" "$gcclibdir/crtend.o" "$arg")
+        else
+            args+=("-lc" "$arg")
+        fi
     else
         args+=("$arg")
     fi


### PR DESCRIPTION
Oops. If we keep the change for the x86_64 linkwrapper but go back to the way things were with arm/musl, it looks like we work ...