### PR TITLE
cross-images/entrypoint.sh: also bind-mount /tmp into Alpine chroot

### DIFF
--- a/cross-images/entrypoint.sh
+++ b/cross-images/entrypoint.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 # need this to set up the bind mounts that will be used by our chroot:
 
 if [ ! -f /did-setup ] ; then
-    for dir in proc sys dev project target cargo xargo rust ; do
+    for dir in proc sys dev project target cargo xargo rust tmp ; do
         mkdir -p /alpine/$dir
         mount --bind /$dir /alpine/$dir
         mount --make-private /alpine/$dir


### PR DESCRIPTION
As of recently, the rust link line includes a reference to some kind of magical object file with a path of form `/tmp/rustcndJdVh/symbols.o`. This didn't work for our Alpine chroot builds because `/tmp` started meaning `/alpine/tmp`, which of course didn't contain the magic temporary. We can easily work around this by bind-mounting `/tmp` into the `/alpine` tree, in the same way that we do for many other directories.