### PR TITLE
Add aarch64

### DIFF
--- a/.azure-pipelines/variables.yml
+++ b/.azure-pipelines/variables.yml
@@ -1,13 +1,12 @@
-# Copyright 2019-2021 the Tectonic Project
+# Copyright 2019-2023 the Tectonic Project
 # Licensed under the MIT License.
 
 # This files sets global variables that are shared among various pipelines.
 
 variables:
-  linux_image: 'ubuntu-18.04'
-  macos_image: 'macOS-10.14'
-  windows_image: 'windows-2019'
+  linux_image: 'ubuntu-latest'
   cross_tag: 'v0.1.16'
+  target_aarch64_unknown_linux_musl: 'aarch64-unknown-linux-musl'
   target_arm_unknown_linux_musleabihf: 'arm-unknown-linux-musleabihf'
   target_i686_unknown_linux_gnu: 'i686-unknown-linux-gnu'
   target_mips_unknown_linux_gnu: 'mips-unknown-linux-gnu'

--- a/.azure-pipelines/variables.yml
+++ b/.azure-pipelines/variables.yml
@@ -9,5 +9,4 @@ variables:
   target_aarch64_unknown_linux_musl: 'aarch64-unknown-linux-musl'
   target_arm_unknown_linux_musleabihf: 'arm-unknown-linux-musleabihf'
   target_i686_unknown_linux_gnu: 'i686-unknown-linux-gnu'
-  target_mips_unknown_linux_gnu: 'mips-unknown-linux-gnu'
   target_x86_64_unknown_linux_musl: 'x86_64-unknown-linux-musl'

--- a/README.md
+++ b/README.md
@@ -17,11 +17,17 @@ copies the binary out of the container to the host.
 
 [`cross`]: https://github.com/cross-rs/cross
 
+See the `README.md` in the `custom-cross` subdirectory for more information.
+
 
 ## Custom `cross` images
 
 As a less weird thing, we need to create custom images used by [`cross`] to
 build Tectonic. Scripts to create them are in the `cross-images/` directory.
+
+See the `README.md` in the `cross-images` subdirectory for more information.
+That file documents the workflow for attempting your own cross-compilation of
+Tectonic.
 
 
 ## Old stuff

--- a/cross-images/01_debian_populate.sh
+++ b/cross-images/01_debian_populate.sh
@@ -8,6 +8,7 @@ export TERM=dumb DEBIAN_FRONTEND=noninteractive
 
 apt-get install -y --no-install-recommends \
         binfmt-support \
+        build-essential \
         crossbuild-essential-${debian_arch} \
         pkg-config \
         qemu \

--- a/cross-images/01_debian_populate.sh
+++ b/cross-images/01_debian_populate.sh
@@ -4,7 +4,9 @@
 
 set -xeuo pipefail
 
-apt-get install -y \
+export TERM=dumb DEBIAN_FRONTEND=noninteractive
+
+apt-get install -y --no-install-recommends \
         binfmt-support \
         crossbuild-essential-${debian_arch} \
         pkg-config \
@@ -30,7 +32,7 @@ fi
 
 # Must do this in two stages because mips openssl messes up amd64 openssl.
 
-apt-get install -y \
+apt-get install -y --no-install-recommends \
         libgraphite2-dev:${debian_arch} \
         libharfbuzz-dev:${debian_arch} \
         libfontconfig1-dev:${debian_arch} \

--- a/cross-images/03_alpine_populate.sh
+++ b/cross-images/03_alpine_populate.sh
@@ -10,12 +10,19 @@ if [ $TARGET_ARCH == native ] ; then
 else
     root=/home/rust/sysroot-$TARGET_ARCH
 
-    # Packages for other architectures are signed with other keys that we need to load up.
+    # Packages for different architectures are signed with different keys; we
+    # need to load up all of them.
+    #
+    # To figure out what key(s) you need for a new arch, download the relevant
+    # `APKINDEX.tar.gz` file that the build requires, e.g.
+    # `https://dl-cdn.alpinelinux.org/alpine/v3.16/community/aarch64/APKINDEX.tar.gz`.
+    # If you list the contents of that file, there should be a `.SIGN.*` file
+    # whose name indicates the signature of the key that is needed.
     cd /etc/apk/keys
     for fp in 4d07755e 524d27bb 58199dcc 58cbb476 58e4f17d ; do
         wget https://alpinelinux.org/keys/alpine-devel@lists.alpinelinux.org-$fp.rsa.pub
     done
-    for fp in 616a9724 ; do
+    for fp in 616a9724 616ae350 ; do
         wget https://git.alpinelinux.org/aports/plain/main/alpine-keys/alpine-devel@lists.alpinelinux.org-$fp.rsa.pub
     done
 

--- a/cross-images/04_ubuntu_priv_setup.sh
+++ b/cross-images/04_ubuntu_priv_setup.sh
@@ -11,7 +11,7 @@ cd /
 
 export TERM=dumb DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y build-essential pkg-config sudo
+apt-get install -y --no-install-recommends build-essential pkg-config sudo
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 

--- a/cross-images/05_ubuntu_unpriv_setup.sh
+++ b/cross-images/05_ubuntu_unpriv_setup.sh
@@ -12,15 +12,17 @@ toolprefix="$3"
 cd
 mkdir $HOME/bin
 
-if [ "$rust_platform" = x86_64-unknown-linux-musl ] ; then
-    # 2021 May: It seems that Rust 1.52 has started bundling more of its
-    # own "crt" files, and we should no longer link with -lgcc, among
-    # other changes. For our other platform that uses this framework,
-    # arm-unknown-linux-musleabihf, we shouldn't change.
-    force_crt=false
-else
-    force_crt=true
-fi
+case "$rust_platform" in
+    x86_64-unknown-linux-musl|aarch64-unknown-linux-musl)
+        # 2021 May: It seems that Rust 1.52 has started bundling more of its
+        # own "crt" files, and we should no longer link with -lgcc, among
+        # other changes, for some platforms
+        force_crt=false
+        ;;
+    *)
+        force_crt=true
+        ;;
+esac
 
 for tmpl in toolwrapper.sh linkwrapper.sh ; do
     sed -e "s|@rust_platform@|$rust_platform|g" \

--- a/cross-images/Dockerfile.debian-cross
+++ b/cross-images/Dockerfile.debian-cross
@@ -9,7 +9,7 @@ ARG debian_platform
 ARG debian_arch
 ARG qemu_arch
 
-ENV TERM=dumb
+ENV TERM=dumb DEBIAN_FRONTEND=noninteractive
 RUN dpkg --add-architecture ${debian_arch} && apt-get update
 ADD 01_debian_populate.sh /
 RUN /bin/bash /01_debian_populate.sh

--- a/cross-images/README.md
+++ b/cross-images/README.md
@@ -120,3 +120,49 @@ specifically by using a [linker wrapper script] suggested by GitHub user
 `@dl00`.
 
 [linker wrapper script]: https://github.com/rust-lang/rust/issues/36710#issuecomment-364623950
+
+
+## The `mini-aports` Tree
+
+The Alpine-based setups in this directory rely on a subtree named `mini-aports`,
+which contains a tiny slice of the Alpine Linux [aports] repository. Every so
+often, this subtree should be synced up with Alpine development.
+
+[aports]: https://github.com/alpinelinux/aports/
+
+This vendoring process involves a special branch named `vendor-aports`. This
+branch derives from a very early iteration of this repository. Its only
+purpose is to be a repository for *pristine* files copied out of the aports
+tree, using a workflow along the lines of:
+
+```
+# this repo
+git checkout vendor-aports
+rm -rf cross-images/mini-aports/main/*
+
+# aports repo
+cd ~/temp
+git clone https://github.com/alpinelinux/aports
+# ... takes a long time
+cd aports
+git checkout 3.16-stable
+cp scripts/bootstrap.sh /path/to/ci-support/cross-images/mini-aports/scripts/
+cd main
+cp -r binutils build-base fortify-headers gcc libc-dev linux-headers musl /path/to/ci-support/cross-images/mini-aports/main/
+
+# back to this repo
+cd /path/to/ci-support
+git add cross-images/mini-aports
+git commit # document source commit, date, etc.
+
+git checkout my-work-branch
+git merge vendor-aports
+# rebuild Docker containers
+```
+
+This framework sets things up so that *if needed*, we can apply patches to the
+aports tree and track them via the Git merge process. So far this has not proved
+to be necessary.
+
+If/when the aports update is demonstrated to be necessary and correct, the
+`vendor-aports` branch on GitHub should be updated.

--- a/cross-images/README.md
+++ b/cross-images/README.md
@@ -76,6 +76,30 @@ it to be necessary to add some truly disgusting hacks to the build framework to
 get things to work. Good luck!
 
 
+## Running the Images Directly
+
+You can't simply `docker run` the `crossbuild` images because they expect to be
+launched in the `cross` program's very specialized Docker environment. The
+following command line can emulate it just enough to give you a shell:
+
+```
+docker run \
+  --privileged \
+  -e HOST_UID=$(id -u) \
+  -e HOST_GID=$(id -g) \
+  -v $(pwd):/xargo \
+  -v $(pwd):/cargo \
+  -v $(pwd):/rust \
+  -v $(pwd):/target \
+  --rm -it \
+  tectonictypesetting/crossbuild:$ARCH bash
+```
+
+To set up an environment that can run an actual build, many more settings are
+needed. The most reasonable way to determine them is to run a program like `ps
+xawww` while a `./cross build` is running.
+
+
 ## Static Build Implementation
 
 A substantial chunk of Tectonic's cross-compilation support is aimed at

--- a/cross-images/README.md
+++ b/cross-images/README.md
@@ -1,23 +1,94 @@
 # Statically-linked Tectonic cross-compilation environment
 
-This Docker recipe creates a container that can be used to build a
-statically-linked Tectonic executable. The process is pretty complex!
+This directory contains Docker recipes that create containers that can be used
+to cross-compile Tectonic for a variety of environments, with an emphasis on
+statically-linked outputs.
 
-We used to build Tectonic inside a pure Alpine Linux container. Everything in
-Alpine uses musl, the static-linking-friendly libc, and it provides a
-toolchain that can create static binaries, and Rust generally supports musl.
-So far so good.
 
-*However*, Tectonic needs “procedural macro” crates to compile, and these
-are not compatible with the Alpine static target. Procedural macros are
-implemented as dynamic modules loaded into the Rust compiler executable.
-On a static target, you ... can't do that.
+## Workflow
 
-It took me a while to figure this out, but the solution is cross-compilation.
-The Rust compiler executable is running on the "build" architecture, whereas
-the output program will run on the "target" architecture. Procedural macros
-should work for a static target architecture *if* the build architecture is
-dynamic — a cross-compilation situation.
+To cross-compile a version of [tectonic] in this framework, the overall workflow
+is as follows. These instructions assume that your host environment is an x86-64
+Linux system; the same workflow should work on other systems, but you will need
+to compile more of the tooling yourself:
+
+[tectonic]: https://github.com/tectonic-typesetting/tectonic/
+
+1. In this directory, build a cross-builder image for your target of interest,
+   using a command such as:
+   ```
+   ./build.x86_64-unknown-linux-musl.sh
+   ```
+   This will generate a Docker image named
+   `tectonictypesetting/crossbuild:x86_64-unknown-linux-musl` (or something
+   analogous if you specify a different target; all appearances of the target
+   name below will likewise track your choice).
+1. Obtain a copy of the [tectonic] source code.
+1. Within the Tectonic source tree, unpack the [custom Tectonic `cross` program][1]:
+   ```
+   docker run --rm -v $(pwd):/work:rw,Z tectonictypesetting/ttcross:latest
+   ```
+1. It is often necessary to delete your entire `target` tree before a new cross
+   build. If you don't, you may see an error like:
+   ```
+   .../build-script-build: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.29' not found
+   ```
+   This is because the containerized cross build is not smart enough to
+   differentiate between build scripts built for your true host OS, and the host
+   OS of the cross Docker container.
+1. Use that program to execute the cross build:
+   ```
+   ./cross build --target=x86_64-unknown-linux-musl --release
+   ```
+1. The final output will be found at
+   `target/x86_64-unknown-linux-musl/release/tectonic`.
+1. The aspiration is that `./cross test ...` will work, although this is often
+   dicey in cross-compilation scenarios. In order to run any cross-compiled binaries,
+   you may need to have QEmu handlers registered with your kernel, which can be
+   achieved conveniently with:
+   ```
+   docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
+   ```
+
+[1]: ../custom-cross/README.md
+
+
+## Adding New Targets
+
+If you want to add a new cross-compilation target, the easiest way to start is
+by duplicating one of the existing `build.*.sh` scripts. *Hopefully* all you
+will need to do is update various parameters.
+
+If your new target is based on an Alpine chroot, you will probably also need to
+update `03_alpine_populate.sh` to add a new key fingerprint so that the Alpine
+install will accept the necessary support packages.
+
+You will also need to add a new entry to the `Cross.toml` file in the toplevel
+[tectonic] source directory, adding a record identifying the Docker build
+container to be used for the new target.
+
+Once you've done the above, the only true test is to attempt a cross build and
+test of Tectonic, and see how far you get. Unfortunately, it is quite common for
+it to be necessary to add some truly disgusting hacks to the build framework to
+get things to work. Good luck!
+
+
+## Static Build Implementation
+
+A substantial chunk of Tectonic's cross-compilation support is aimed at
+providing static builds of the `tectonic` executable. What does
+cross-compilation have to do with building static binaries, you might ask?
+
+The key is that Tectonic needs “procedural macro” (AKA “proc macro”) crates to
+compile. Procedural macros are implemented as dynamic modules loaded into the
+Rust compiler executable. If you are building on a fully static target, you ...
+just can't do that.
+
+The solution is to approach the build as a cross-compilation. In a cross build,
+the Rust compiler executable is running on the "build" architecture, but
+compiling the output program to run on the "target" architecture. Even if the
+target architecture is static, we can have procedural macros if the *build*
+architecture is dynamic.
 
 Cross-compilation is gnarly for Tectonic because we depend on several system
 libraries, like Harfbuzz and Freetype. If we're going to cross-compile, we
@@ -49,77 +120,3 @@ specifically by using a [linker wrapper script] suggested by GitHub user
 `@dl00`.
 
 [linker wrapper script]: https://github.com/rust-lang/rust/issues/36710#issuecomment-364623950
-
-**Note**: Our CI runs this docker container inside its own Ubuntu Xenial VM.
-The way that we do things now, we could just skip Docker altogether and set up
-the Alpine chroot inside the VM directly. But it seems helpful to capture the
-magic in a Docker setup and shouldn't slow things down much, so we'll stick
-with the container.
-
-## How to Build Your Very Own Static Binary
-
-Because we use docker to create this environment you can easily build a static `tectonic` yourself.
-
-### prerequisites
-* You'll need to have [docker installed](https://docs.docker.com/install/).
-* local copy of this repository. The steps below assume you have cloned the repository and are in its root.
-* a modern shell. Note the below commands should work in most shells but may not in some. For example, if using [fishshell](https://fishshell.com/) you'll have to update the environment flag assignment and `pwd` invocation.
-
-
-### steps
-
-1. build an image that correctly sets up the needed environment
-```
-$ DOCKER_BUILDKIT=1 docker build -t tectonic-cross-compiler:v1 dist/docker/x86_64-alpine-linux-musl/
-```
-This will take a while. You should see output similar to below:
-```
-[+] Building 95.7s (15/15) FINISHED
- => [internal] load build definition from Dockerfile                                                                                                                         0.0s
- => => transferring dockerfile: 953B                                                                                                                                         0.0s
- => [internal] load .dockerignore                                                                                                                                            0.0s
- => => transferring context: 2B                                                                                                                                              0.0s
- => [internal] load metadata for docker.io/library/ubuntu:18.04                                                                                                              0.0s
- => [internal] load build context                                                                                                                                            0.0s
- => => transferring context: 4.33kB                                                                                                                                          0.0s
- => [1/10] FROM docker.io/library/ubuntu:18.04                                                                                                                               0.0s
- => => resolve docker.io/library/ubuntu:18.04                                                                                                                                0.0s
- => [2/10] ADD setup_priv.sh /                                                                                                                                               0.1s
- => [3/10] RUN sh /setup_priv.sh                                                                                                                                            41.6s
- => [4/10] ADD sudoers /etc/sudoers.d/nopasswd                                                                                                                               0.2s
- => [5/10] ADD setup_unpriv.sh /                                                                                                                                             0.1s
- => [6/10] ADD toolwrapper.sh /alpine/home/rust/                                                                                                                             0.1s
- => [7/10] ADD linkwrapper.sh /alpine/home/rust/                                                                                                                             0.1s
- => [8/10] RUN sh /setup_unpriv.sh                                                                                                                                          43.9s
- => [9/10] ADD cargo-config.toml /alpine/home/rust/.cargo/config                                                                                                             0.1s
- => [10/10] WORKDIR /alpine/home/rust/src                                                                                                                                    0.1s
- => exporting to image                                                                                                                                                       9.1s
- => => exporting layers                                                                                                                                                      9.1s
- => => writing image sha256:842075298248fc0c885d77e25ae244833551c08a400bd252445620763d031a82                                                                                 0.0s
- => => naming to docker.io/library/tectonic-cross-compiler:v1
-```
-[BuildKit](https://github.com/moby/buildkit) is an improved toolkit that [docker can take advantage](https://docs.docker.com/develop/develop-images/build_enhancements/) of by toggling the environment variable.
-
-2. run a container that [invokes cargo](https://github.com/tectonic-typesetting/tectonic/blob/master/dist/docker/x86_64-alpine-linux-musl/Dockerfile#L31) to build the static binary
-```
-$ docker run --rm -v $(pwd):/alpine/home/rust/src tectonic-cross-compiler:v1
-    Updating crates.io index
- Downloading crates ...
-  Downloaded aho-corasick v0.7.6
-  Downloaded lazy_static v1.3.0
-  Downloaded error-chain v0.12.1
-```
-This will also take some time. You should see cargo's output from compiling crates.
-Upon completing, it should create the static binary in your working directory's `target/x86_64-unknown-linux-musl/release/`:
-```
- $ ls target/x86_64-unknown-linux-musl/release/tectonic
-target/x86_64-unknown-linux-musl/release/tectonic*
-```
-
-Now you should be able to copy that `tectonic` binary to any Linux system it should *just work*:
-```
-some-box $ ./tectonic -V
-Tectonic 0.1.12-dev
-```
-
-Three cheers for cross compilation!

--- a/cross-images/README.md
+++ b/cross-images/README.md
@@ -63,6 +63,9 @@ If your new target is based on an Alpine chroot, you will probably also need to
 update `03_alpine_populate.sh` to add a new key fingerprint so that the Alpine
 install will accept the necessary support packages.
 
+You also need to add the target to `.azure-pipelines/variables.yml` to integrate
+the new architecture into the CI/CD pipeline.
+
 You will also need to add a new entry to the `Cross.toml` file in the toplevel
 [tectonic] source directory, adding a record identifying the Docker build
 container to be used for the new target.

--- a/cross-images/build.aarch64-unknown-linux-musl.sh
+++ b/cross-images/build.aarch64-unknown-linux-musl.sh
@@ -1,0 +1,19 @@
+#! /usr/bin/env bash
+# Copyright 2023 The Tectonic Project
+# Licensed under the MIT License.
+
+[ -n "$IMGUID" ] || IMGUID="$(id -u)"
+rust_platform=aarch64-unknown-linux-musl
+alpine_platform=aarch64-alpine-linux-musl
+alpine_arch=aarch64
+qemu_arch=aarch64
+
+cd "$(dirname $0)" && exec docker build \
+       -t tectonictypesetting/crossbuild:$rust_platform \
+       -f Dockerfile.alpine-chroot-cross \
+       --build-arg UID=$IMGUID \
+       --build-arg rust_platform=$rust_platform \
+       --build-arg alpine_platform=$alpine_platform \
+       --build-arg alpine_arch=$alpine_arch \
+       --build-arg qemu_arch=$qemu_arch \
+       .

--- a/cross-images/build.mips-unknown-linux-gnu.sh
+++ b/cross-images/build.mips-unknown-linux-gnu.sh
@@ -2,6 +2,10 @@
 # Copyright 2019 The Tectonic Project
 # Licensed under the MIT License.
 
+# NOTE: As of summer 2023, Rust has dropped MIPS to Tier 3 support, so it has
+# been removed from Tectonic's CI system. This file is preserved for posterity
+# but is unlikely to remain functional for long.
+
 [ -n "$IMGUID" ] || IMGUID="$(id -u)"
 rust_platform=mips-unknown-linux-gnu
 debian_platform=mips-linux-gnu

--- a/cross-images/mini-aports/main/binutils/APKBUILD
+++ b/cross-images/mini-aports/main/binutils/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Ariadne Conill <ariadne@dereferenced.org>
 pkgname=binutils
 pkgver=2.38
-pkgrel=2
+pkgrel=3
 pkgdesc="Tools necessary to build programs"
 url="https://www.gnu.org/software/binutils/"
 makedepends_build="bison flex texinfo"
@@ -20,6 +20,7 @@ source="https://ftp.gnu.org/gnu/binutils/binutils-$pkgver.tar.xz
 	binutils-ppc-fix-machine-options.patch
 	binutils-s390x-1.patch
 	binutils-s390x-2.patch
+	binutils-ppc64le-assertion.patch
 	"
 builddir="$srcdir/$pkgname-$pkgver"
 
@@ -144,4 +145,5 @@ f55cf2e0bf82f97583a1abe10710e4013ecf7d64f1da2ef8659a44a06d0dd8beaf58dab98a183488
 27ea91e0e406e2ed464fd692cf92a07e338781789f2d968c8b95d9d5545985056a6f7f500df3952e5ab42165db28b741aa33d6b717e880b11a2e41fe406b13c4  binutils-ppc-fix-machine-options.patch
 a9efe2689624865f0ff33d4776a5bd295bcad6484bdd38d0ca490fea43691c4933ab33d17478851998eef12922dbf83d6c3225bb1f8faf92a1367d086390f7d3  binutils-s390x-1.patch
 0e291df80ad279005265634014d0935d2c115a5ed708d25407094b7ad4ddf267d1fb7fcbcb2d9ad73bd305b4e3974628b820bd1f249f56c095e4896872434cc9  binutils-s390x-2.patch
+63e58f45df3570279cb1ee5215ba3de77de012cac20da9cdd23f86a93890056e1efa397521559cfd0716d5239604607c440d8f4d089d83c98b8fbc1b5c5305f8  binutils-ppc64le-assertion.patch
 "

--- a/cross-images/mini-aports/main/binutils/binutils-ppc64le-assertion.patch
+++ b/cross-images/mini-aports/main/binutils/binutils-ppc64le-assertion.patch
@@ -1,0 +1,32 @@
+From 97dd8079feb35456d7b387a594b5e00f7654b3b8 Mon Sep 17 00:00:00 2001
+From: Alan Modra <amodra@gmail.com>
+Date: Thu, 23 Jun 2022 17:50:30 +0930
+Subject: [PATCH] PowerPC64: fix assertion in ppc_build_one_stub with -Os code
+
+save_res stubs aren't written in ppc_build_one_stub, their offsets
+(which are zero) should not be checked.
+
+	* elf64-ppc.c (ppc_build_one_stub): Don't check save_res offsets.
+
+(cherry picked from commit 570e911f4e533fad33ad5e4e1102929cf7e80bd7)
+---
+ bfd/elf64-ppc.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/bfd/elf64-ppc.c b/bfd/elf64-ppc.c
+index cb12ed476d8..df503341fe9 100644
+--- a/bfd/elf64-ppc.c
++++ b/bfd/elf64-ppc.c
+@@ -11700,7 +11700,8 @@ ppc_build_one_stub (struct bfd_hash_entry *gen_entry, void *in_arg)
+   if (htab == NULL)
+     return false;
+ 
+-  BFD_ASSERT (stub_entry->stub_offset >= stub_entry->group->stub_sec->size);
++  BFD_ASSERT (stub_entry->stub_offset >= stub_entry->group->stub_sec->size
++	      || stub_entry->type.main == ppc_stub_save_res);
+   loc = stub_entry->group->stub_sec->contents + stub_entry->stub_offset;
+ 
+   htab->stub_count[stub_entry->type.main - 1] += 1;
+-- 
+2.31.1
+

--- a/cross-images/mini-aports/main/musl/0001-fix-mishandling-of-errno-in-getaddrinfo-AI_ADDRCONFI.patch
+++ b/cross-images/mini-aports/main/musl/0001-fix-mishandling-of-errno-in-getaddrinfo-AI_ADDRCONFI.patch
@@ -1,0 +1,41 @@
+From 7d568410b455390362e2bcfb7c50fcf9c8833d9b Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Mon, 1 Aug 2022 12:54:23 -0400
+Subject: [PATCH] fix mishandling of errno in getaddrinfo AI_ADDRCONFIG logic
+
+this code attempts to use the value of errno from failure of socket or
+connect to infer availability of the requested address family (v4 or
+v6). however, in the case where connect failed, there is an
+intervening call to close between connect and the use of errno. close
+is not required to preserve errno on success, and in fact the
+__aio_close code, which is called whenever aio is linked and thus
+always called in dynamic-linked programs, unconditionally clobbers
+errno. as a result, getaddrinfo fails with EAI_SYSTEM and errno=ENOENT
+rather than correctly determining that the address family was
+unavailable.
+
+this fix is based on report/patch by Jussi Nieminen, but simplified
+slightly to avoid breaking the case where socket, not connect, failed.
+---
+ src/network/getaddrinfo.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/network/getaddrinfo.c b/src/network/getaddrinfo.c
+index efaab3068..9df045f6b 100644
+--- a/src/network/getaddrinfo.c
++++ b/src/network/getaddrinfo.c
+@@ -66,9 +66,11 @@ int getaddrinfo(const char *restrict host, const char *restrict serv, const stru
+ 				pthread_setcancelstate(
+ 					PTHREAD_CANCEL_DISABLE, &cs);
+ 				int r = connect(s, ta[i], tl[i]);
++				int saved_errno = errno;
+ 				pthread_setcancelstate(cs, 0);
+ 				close(s);
+ 				if (!r) continue;
++				errno = saved_errno;
+ 			}
+ 			switch (errno) {
+ 			case EADDRNOTAVAIL:
+-- 
+2.40.1
+

--- a/cross-images/mini-aports/main/musl/0001-fix-return-value-of-gethostby-name-2-addr-with-no-re.patch
+++ b/cross-images/mini-aports/main/musl/0001-fix-return-value-of-gethostby-name-2-addr-with-no-re.patch
@@ -1,0 +1,44 @@
+From 8f9259450aa43a6fd539e428e61e2961b725fbae Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Thu, 20 Oct 2022 19:48:32 -0400
+Subject: [PATCH] fix return value of gethostby{name[2],addr} with no result
+ but no error
+
+commit f081d5336a80b68d3e1bed789cc373c5c3d6699b fixed
+gethostbyname[2]_r to treat negative results as a non-error, leaving
+gethostbyname[2] wrongly returning a pointer to the unfilled result
+buffer rather than a null pointer. since, as documented with commit
+fe82bb9b921be34370e6b71a1c6f062c20999ae0, the caller of
+gethostby{name[2],addr}_r can always rely on the result pointer being
+set, use that consistently rather than trying to duplicate logic about
+whether we have a result or not in gethostby{name[2],addr}.
+---
+ src/network/gethostbyaddr.c  | 2 +-
+ src/network/gethostbyname2.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/network/gethostbyaddr.c b/src/network/gethostbyaddr.c
+index 598e2241..c3cacaac 100644
+--- a/src/network/gethostbyaddr.c
++++ b/src/network/gethostbyaddr.c
+@@ -20,5 +20,5 @@ struct hostent *gethostbyaddr(const void *a, socklen_t l, int af)
+ 		err = gethostbyaddr_r(a, l, af, h,
+ 			(void *)(h+1), size-sizeof *h, &res, &h_errno);
+ 	} while (err == ERANGE);
+-	return err ? 0 : h;
++	return res;
+ }
+diff --git a/src/network/gethostbyname2.c b/src/network/gethostbyname2.c
+index dc9d6621..bd0da7f8 100644
+--- a/src/network/gethostbyname2.c
++++ b/src/network/gethostbyname2.c
+@@ -21,5 +21,5 @@ struct hostent *gethostbyname2(const char *name, int af)
+ 		err = gethostbyname2_r(name, af, h,
+ 			(void *)(h+1), size-sizeof *h, &res, &h_errno);
+ 	} while (err == ERANGE);
+-	return err ? 0 : h;
++	return res;
+ }
+-- 
+2.40.1
+

--- a/cross-images/mini-aports/main/musl/0001-fix-return-value-of-gethostnbyname-2-_r-on-result-no.patch
+++ b/cross-images/mini-aports/main/musl/0001-fix-return-value-of-gethostnbyname-2-_r-on-result-no.patch
@@ -1,0 +1,30 @@
+From f081d5336a80b68d3e1bed789cc373c5c3d6699b Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Mon, 19 Sep 2022 19:02:40 -0400
+Subject: [PATCH] fix return value of gethostnbyname[2]_r on result not found
+
+these functions are horribly underspecified, inconsistent between
+historical systems, and should never have been included. however, the
+signatures we have match the glibc ones, and the glibc behavior is to
+treat NxDomain and NODATA results as a success condition, not an
+ENOENT error.
+---
+ src/network/gethostbyname2_r.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/network/gethostbyname2_r.c b/src/network/gethostbyname2_r.c
+index fc894877..f012ec2f 100644
+--- a/src/network/gethostbyname2_r.c
++++ b/src/network/gethostbyname2_r.c
+@@ -22,7 +22,7 @@ int gethostbyname2_r(const char *name, int af,
+ 	if (cnt<0) switch (cnt) {
+ 	case EAI_NONAME:
+ 		*err = HOST_NOT_FOUND;
+-		return ENOENT;
++		return 0;
+ 	case EAI_AGAIN:
+ 		*err = TRY_AGAIN;
+ 		return EAGAIN;
+-- 
+2.40.1
+

--- a/cross-images/mini-aports/main/musl/0001-remove-impossible-error-case-from-gethostbyname2_r.patch
+++ b/cross-images/mini-aports/main/musl/0001-remove-impossible-error-case-from-gethostbyname2_r.patch
@@ -1,0 +1,29 @@
+From f9827fc7da55c7b03ea5f36598ce8782c03e9d6e Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Mon, 19 Sep 2022 19:09:02 -0400
+Subject: [PATCH] remove impossible error case from gethostbyname2_r
+
+EAI_MEMORY is not possible because the resolver backend does not
+allocate. if it did, it would be necessary for us to explicitly return
+ENOMEM as the error, since errno is not guaranteed to reflect the
+error cause except in the case of EAI_SYSTEM, so the existing code was
+not correct anyway.
+---
+ src/network/gethostbyname2_r.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/src/network/gethostbyname2_r.c b/src/network/gethostbyname2_r.c
+index f012ec2f..c9f3acc4 100644
+--- a/src/network/gethostbyname2_r.c
++++ b/src/network/gethostbyname2_r.c
+@@ -30,7 +30,6 @@ int gethostbyname2_r(const char *name, int af,
+ 	case EAI_FAIL:
+ 		*err = NO_RECOVERY;
+ 		return EBADMSG;
+-	case EAI_MEMORY:
+ 	case EAI_SYSTEM:
+ 		*err = NO_RECOVERY;
+ 		return errno;
+-- 
+2.40.1
+

--- a/cross-images/mini-aports/main/musl/APKBUILD
+++ b/cross-images/mini-aports/main/musl/APKBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Timo Teräs <timo.teras@iki.fi>
 pkgname=musl
 pkgver=1.2.3
-pkgrel=0
+pkgrel=3
 pkgdesc="the musl c library (libc) implementation"
 url="https://musl.libc.org/"
 arch="all"
@@ -22,6 +22,16 @@ esac
 _commit="v1.2.3"
 source="musl-$_commit.tar.gz::https://git.musl-libc.org/cgit/musl/snapshot/$_commit.tar.gz
 	handle-aux-at_base.patch
+
+	0001-fix-mishandling-of-errno-in-getaddrinfo-AI_ADDRCONFI.patch
+	0001-fix-return-value-of-gethostby-name-2-addr-with-no-re.patch
+	0001-fix-return-value-of-gethostnbyname-2-_r-on-result-no.patch
+	0001-remove-impossible-error-case-from-gethostbyname2_r.patch
+
+	relr-1.patch
+	relr-2.patch
+	relr-3.patch
+	relr-4.patch
 
 	ldconfig
 	__stack_chk_fail_local.c
@@ -166,6 +176,14 @@ compat() {
 sha512sums="
 9a1b8f9208d99582ac00e3c46c829aa1fad3b7f09aa7d6822f02f25542453d3d977c69519ad01430b8dd624ac9dc70f47d611e36aefd7fef31ea47a7679e3111  musl-v1.2.3.tar.gz
 a76f79b801497ad994746cf82bb6eaf86f9e1ae646e6819fbae8532a7f4eee53a96ac1d4e789ec8f66aea2a68027b0597f7a579b3369e01258da8accfce41370  handle-aux-at_base.patch
+63a7b65c2f508b0811f172d3b55da27a4b372653e01339d2f9e2b81bd61e7848ab317a6676a9440f50695658043cdede24881f8545f96bb291dd1f9b669ac08d  0001-fix-mishandling-of-errno-in-getaddrinfo-AI_ADDRCONFI.patch
+b937a2c7f5adc51d23c731436b97152afbb147f98a4f33fa644fe2fe1aebea7da4519da4eb96acd73426660ce5dfe70cc27b8868e95a0322d74bc7aff4d8bddb  0001-fix-return-value-of-gethostby-name-2-addr-with-no-re.patch
+c917d3b2667fa2485ca7ee568f73ef160957dc4652e7e95e7cdebdf521bed55e16c56da7b6afcce72bfd7b13b7282a36211e08061b4fc9ded0142791a7badd6e  0001-fix-return-value-of-gethostnbyname-2-_r-on-result-no.patch
+2ed9de660b5e0f2b6aca195d7759c87ac85b515cb75bd73222b9d9dda00a6c5b07704ebd1507d2fbf925501c45f40cfb27244a05cad7a4da1f53f8f63ca4e5ae  0001-remove-impossible-error-case-from-gethostbyname2_r.patch
+8ebcde1e07819de208ab89ed0a71fdcc67a5b1cecec5aa19a92bc9f4f3c2708a9ff1528370089de0b71e9ec3b2e08dfa49694db433ac190ba055aa112ae12bde  relr-1.patch
+38b40ebedf57ba05ba14807a55a26261eeca8b6226a90a7aaebaaa31bae0bb7f5b98e0ce3ed727b704b828c9e509a21745f3e089585f8dea7092be164ec9d908  relr-2.patch
+9dc41f682887ef9a7b00253f576d0b738936c20d9bc5a54fa96552a82a2f056f0111936ad9778b96745befd6a660276618b4e05bef3c7f52d8c2a9e6d41e386c  relr-3.patch
+ee6ec5943df10597af0df3d6f792720a22d2070debb6933656a10a906725d1170c28c32ba8ad53efc72e77bd1d97efdbd3c80e91eddb856f377e917ff14ae8f3  relr-4.patch
 8d3a2d5315fc56fee7da9abb8b89bb38c6046c33d154c10d168fb35bfde6b0cf9f13042a3bceee34daf091bc409d699223735dcf19f382eeee1f6be34154f26f  ldconfig
 062bb49fa54839010acd4af113e20f7263dde1c8a2ca359b5fb2661ef9ed9d84a0f7c3bc10c25dcfa10bb3c5a4874588dff636ac43d5dbb3d748d75400756d0b  __stack_chk_fail_local.c
 0d80f37b34a35e3d14b012257c50862dfeb9d2c81139ea2dfa101d981d093b009b9fa450ba27a708ac59377a48626971dfc58e20a3799084a65777a0c32cbc7d  getconf.c

--- a/cross-images/mini-aports/main/musl/relr-1.patch
+++ b/cross-images/mini-aports/main/musl/relr-1.patch
@@ -1,0 +1,100 @@
+From d32dadd60efb9d3b255351a3b532f8e4c3dd0db1 Mon Sep 17 00:00:00 2001
+From: Fangrui Song <i@maskray.me>
+Date: Tue, 2 Aug 2022 17:24:47 -0400
+Subject: ldso: support DT_RELR relative relocation format
+
+this resolves DT_RELR relocations in non-ldso, dynamic-linked objects.
+---
+ include/elf.h          |  8 ++++++--
+ ldso/dynlink.c         | 21 ++++++++++++++++++++-
+ src/internal/dynlink.h |  2 +-
+ 3 files changed, 27 insertions(+), 4 deletions(-)
+
+diff --git a/include/elf.h b/include/elf.h
+index 86e2f0bb..9e980a29 100644
+--- a/include/elf.h
++++ b/include/elf.h
+@@ -385,7 +385,8 @@ typedef struct {
+ #define SHT_PREINIT_ARRAY 16
+ #define SHT_GROUP	  17
+ #define SHT_SYMTAB_SHNDX  18
+-#define	SHT_NUM		  19
++#define SHT_RELR	  19
++#define	SHT_NUM		  20
+ #define SHT_LOOS	  0x60000000
+ #define SHT_GNU_ATTRIBUTES 0x6ffffff5
+ #define SHT_GNU_HASH	  0x6ffffff6
+@@ -754,7 +755,10 @@ typedef struct {
+ #define DT_PREINIT_ARRAY 32
+ #define DT_PREINIT_ARRAYSZ 33
+ #define DT_SYMTAB_SHNDX	34
+-#define	DT_NUM		35
++#define DT_RELRSZ	35
++#define DT_RELR		36
++#define DT_RELRENT	37
++#define	DT_NUM		38
+ #define DT_LOOS		0x6000000d
+ #define DT_HIOS		0x6ffff000
+ #define DT_LOPROC	0x70000000
+diff --git a/ldso/dynlink.c b/ldso/dynlink.c
+index cc677952..e92f03cb 100644
+--- a/ldso/dynlink.c
++++ b/ldso/dynlink.c
+@@ -210,7 +210,8 @@ static void decode_vec(size_t *v, size_t *a, size_t cnt)
+ 	size_t i;
+ 	for (i=0; i<cnt; i++) a[i] = 0;
+ 	for (; v[0]; v+=2) if (v[0]-1<cnt-1) {
+-		a[0] |= 1UL<<v[0];
++		if (v[0] < 8*sizeof(long))
++			a[0] |= 1UL<<v[0];
+ 		a[v[0]] = v[1];
+ 	}
+ }
+@@ -515,6 +516,23 @@ static void do_relocs(struct dso *dso, size_t *rel, size_t rel_size, size_t stri
+ 	}
+ }
+ 
++static void do_relr_relocs(struct dso *dso, size_t *relr, size_t relr_size)
++{
++	unsigned char *base = dso->base;
++	size_t *reloc_addr;
++	for (; relr_size; relr++, relr_size-=sizeof(size_t))
++		if ((relr[0]&1) == 0) {
++			reloc_addr = laddr(dso, relr[0]);
++			*reloc_addr++ += (size_t)base;
++		} else {
++			int i = 0;
++			for (size_t bitmap=relr[0]; (bitmap>>=1); i++)
++				if (bitmap&1)
++					reloc_addr[i] += (size_t)base;
++			reloc_addr += 8*sizeof(size_t)-1;
++		}
++}
++
+ static void redo_lazy_relocs()
+ {
+ 	struct dso *p = lazy_head, *next;
+@@ -1357,6 +1375,7 @@ static void reloc_all(struct dso *p)
+ 			2+(dyn[DT_PLTREL]==DT_RELA));
+ 		do_relocs(p, laddr(p, dyn[DT_REL]), dyn[DT_RELSZ], 2);
+ 		do_relocs(p, laddr(p, dyn[DT_RELA]), dyn[DT_RELASZ], 3);
++		do_relr_relocs(p, laddr(p, dyn[DT_RELR]), dyn[DT_RELRSZ]);
+ 
+ 		if (head != &ldso && p->relro_start != p->relro_end) {
+ 			long ret = __syscall(SYS_mprotect, laddr(p, p->relro_start),
+diff --git a/src/internal/dynlink.h b/src/internal/dynlink.h
+index 51c0639f..830354eb 100644
+--- a/src/internal/dynlink.h
++++ b/src/internal/dynlink.h
+@@ -93,7 +93,7 @@ struct fdpic_dummy_loadmap {
+ #endif
+ 
+ #define AUX_CNT 32
+-#define DYN_CNT 32
++#define DYN_CNT 37
+ 
+ typedef void (*stage2_func)(unsigned char *, size_t *);
+ 
+-- 
+cgit v1.2.1
+

--- a/cross-images/mini-aports/main/musl/relr-2.patch
+++ b/cross-images/mini-aports/main/musl/relr-2.patch
@@ -1,0 +1,31 @@
+From bf99258564fd5b58974d93201ab61506eb8cb03e Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Tue, 2 Aug 2022 17:29:01 -0400
+Subject: ldso: process RELR only for non-FDPIC archs
+
+the way RELR is applied is not a meaningful operation for FDPIC (there
+is no single "base" address). it seems unlikely RELR would ever be
+added for FDPIC, but if it ever is, the behavior and possibly data
+format will need to be different, so guard against calling the
+non-FDPIC code.
+---
+ ldso/dynlink.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/ldso/dynlink.c b/ldso/dynlink.c
+index e92f03cb..fd09ca69 100644
+--- a/ldso/dynlink.c
++++ b/ldso/dynlink.c
+@@ -1375,7 +1375,8 @@ static void reloc_all(struct dso *p)
+ 			2+(dyn[DT_PLTREL]==DT_RELA));
+ 		do_relocs(p, laddr(p, dyn[DT_REL]), dyn[DT_RELSZ], 2);
+ 		do_relocs(p, laddr(p, dyn[DT_RELA]), dyn[DT_RELASZ], 3);
+-		do_relr_relocs(p, laddr(p, dyn[DT_RELR]), dyn[DT_RELRSZ]);
++		if (!DL_FDPIC)
++			do_relr_relocs(p, laddr(p, dyn[DT_RELR]), dyn[DT_RELRSZ]);
+ 
+ 		if (head != &ldso && p->relro_start != p->relro_end) {
+ 			long ret = __syscall(SYS_mprotect, laddr(p, p->relro_start),
+-- 
+cgit v1.2.1
+

--- a/cross-images/mini-aports/main/musl/relr-3.patch
+++ b/cross-images/mini-aports/main/musl/relr-3.patch
@@ -1,0 +1,46 @@
+From 6f3ead0ae16deb9f0004b275e29a276c9712ee3c Mon Sep 17 00:00:00 2001
+From: Rich Felker <dalias@aerifal.cx>
+Date: Mon, 12 Sep 2022 08:30:36 -0400
+Subject: process DT_RELR relocations in ldso-startup/static-pie
+
+commit d32dadd60efb9d3b255351a3b532f8e4c3dd0db1 added DT_RELR
+processing for programs and shared libraries processed by the dynamic
+linker, but left them unsupported in the dynamic linker itseld and in
+static pie binaries, which self-relocate via code in dlstart.c.
+
+add the equivalent processing to this code path so that there are not
+arbitrary restrictions on where the new packed relative relocation
+form can be used.
+---
+ ldso/dlstart.c | 15 +++++++++++++++
+ 1 file changed, 15 insertions(+)
+
+diff --git a/ldso/dlstart.c b/ldso/dlstart.c
+index 20d50f2c..259f5e18 100644
+--- a/ldso/dlstart.c
++++ b/ldso/dlstart.c
+@@ -140,6 +140,21 @@ hidden void _dlstart_c(size_t *sp, size_t *dynv)
+ 		size_t *rel_addr = (void *)(base + rel[0]);
+ 		*rel_addr = base + rel[2];
+ 	}
++
++	rel = (void *)(base+dyn[DT_RELR]);
++	rel_size = dyn[DT_RELRSZ];
++	size_t *relr_addr = 0;
++	for (; rel_size; rel++, rel_size-=sizeof(size_t)) {
++		if ((rel[0]&1) == 0) {
++			relr_addr = (void *)(base + rel[0]);
++			*relr_addr++ += base;
++		} else {
++			for (size_t i=0, bitmap=rel[0]; bitmap>>=1; i++)
++				if (bitmap&1)
++					relr_addr[i] += base;
++			relr_addr += 8*sizeof(size_t)-1;
++		}
++	}
+ #endif
+ 
+ 	stage2_func dls2;
+-- 
+cgit v1.2.1
+

--- a/cross-images/mini-aports/main/musl/relr-4.patch
+++ b/cross-images/mini-aports/main/musl/relr-4.patch
@@ -1,0 +1,12 @@
+diff --git a/ldso/dynlink.c b/ldso/dynlink.c
+index 7b47b163..753de91d 100644
+--- a/ldso/dynlink.c
++++ b/ldso/dynlink.c
+@@ -552,6 +552,7 @@ static void do_relocs(struct dso *dso, size_t *rel, size_t rel_size, size_t stri
+ 
+ static void do_relr_relocs(struct dso *dso, size_t *relr, size_t relr_size)
+ {
++	if (dso == &ldso) return; // self-relocation already done a entry point
+ 	unsigned char *base = dso->base;
+ 	size_t *reloc_addr;
+ 	for (; relr_size; relr++, relr_size-=sizeof(size_t))

--- a/custom-cross/README.md
+++ b/custom-cross/README.md
@@ -1,18 +1,47 @@
-# Tectonic CI support: custom `cross` build
+# Tectonic CI support: custom `cross` program
 
 This section of the repository creates a Docker container that hosts a
-customized build of the
-[rust-embedded cross](https://github.com/rust-embedded/cross) command. We
-patch it to run the build containers with the `--privileged` option, which is
-necessary to enable the chroot magic that happens inside the builders. Because
-of this we have to enter the container as root and have it switch to the
+customized build of the [cross](https://github.com/cross-rs/cross) command.
+
+
+## Installation
+
+To install the custom `cross` program, run:
+
+```
+docker run --rm -v $(pwd):/work:rw,Z tectonictypesetting/ttcross:latest
+```
+
+This will copy a file named `cross` into the current directory (or whatever you
+mount to `/work` within the Docker container). The file is an x86-64 Linux
+executable with minimal dependencies.
+
+This is basically a silly way to distribute a pre-built binary, and it could be
+superseded with any of a variety of other mechanisms. But it's what we have
+right now.
+
+
+## Development
+
+The files in this directory can be used to build the
+`tectonictypesetting/ttcross` Docker image referenced above. Run:
+
+```
+docker build -t tectonictypesetting/ttcross:latest .
+```
+
+This framework is currently based on a very old version of the `cross` program,
+and its build infrastructure could use a refresh. Fortunately (sort of), the
+existing program suffices for Tectonic’s CI.
+
+
+## Modifications
+
+We patch `cross` to run the build containers with the `--privileged` option,
+which is necessary to enable the chroot magic that happens inside the builders.
+Because of this we have to enter the container as root and have it switch to the
 correct (host) UID.
 
 We also patch it to mount the `/project` directory as read-write, since the
 Tectonic test suite wants to create a few files there. The test suite should
 be fixed to emit these into `/target`, but I'm being lazy.
-
-The `cross` command has to run on the host machine, but fortunately it has no
-unusual library dependencies. So, running the container just copies the binary
-out to the host machine, which can then run it. This is a bit silly, but gets
-the job done for our main CI applications.


### PR DESCRIPTION
This doesn't fully work yet! Running into the following error on the actual Tectonic build:

```
[linking the final tectonic executable:]
          /home/rust/sysroot-aarch64/usr/lib/libc.a(sigsetjmp.lo): in function `sigsetjmp':
          /home/buildozer/aports/main/musl/src/v1.2.3/src/signal/aarch64/sigsetjmp.s:7:(.text+0x0): relocation truncated to fit: R_AARCH64_CONDBR19 against symbol `setjmp' defined in .text section in /home/rust/sysroot-aarch64/usr/lib/libc.a(setjmp.lo)
          collect2: error: ld returned 1 exit status
```
