### PR TITLE
Also install ca-certs in debian environment

### DIFF
--- a/cross-images/01_debian_populate.sh
+++ b/cross-images/01_debian_populate.sh
@@ -13,7 +13,8 @@ apt-get install -y --no-install-recommends \
         pkg-config \
         qemu \
         qemu-user-static \
-        sudo
+        sudo \
+        ca-certificates
 
 # for x86, we have to specify the platform as i386, but the GCC executables are
 # named as `i686-linux-gnu...`, which messes things up later. Work around with


### PR DESCRIPTION
This is needed for any cross builds which use the base debian environment, without Ubuntu on top